### PR TITLE
fix unregisterShutdownFunction

### DIFF
--- a/lib/Request.class.php
+++ b/lib/Request.class.php
@@ -279,7 +279,7 @@ class Request {
 	 */
 	public function unregisterShutdownFunction($callback) {
 		if (($k = array_search($callback, $this->shutdownFuncs)) !== FALSE) {
-			$this->shutdownFuncs[] = $callback;
+			unset($this->shutdownFuncs[$k]);
 		}
 	}
 


### PR DESCRIPTION
fix unregisterShutdownFunction - remove callback function from array instead of adding this callback again
