### PR TITLE
Syntax fix on 33

### DIFF
--- a/bin/phpd
+++ b/bin/phpd
@@ -30,7 +30,7 @@ require 'PHPDaemon/Core/Daemon.php';
 require 'PHPDaemon/Core/Debug.php';
 $autoloader = function ($classname) {
 	$base = str_replace('\\', '/', $classname);
-	$subpath = [$base . '.php', $base . '.class.php'];
+	$subpath = array($base . '.php', $base . '.class.php');
 	$e       = explode(':', get_include_path());
 	foreach ($e as $path) {
 		foreach ($subpath as $item) {


### PR DESCRIPTION
Wrong array call with "[]" as in js, replaced with "array()"
Parse error: syntax error, unexpected '[' in test.php on line 33
