### PR TITLE
Remove using EventHandlers trait

### DIFF
--- a/PHPDaemon/Clients/Asterisk/Connection.php
+++ b/PHPDaemon/Clients/Asterisk/Connection.php
@@ -15,8 +15,6 @@ use PHPDaemon\Traits\EventHandlers;
  */
 class Connection extends ClientConnection {
 
-	use \PHPDaemon\Traits\EventHandlers;
-
 	/**
 	 * @TODO DESCR
 	 */


### PR DESCRIPTION
EventHandlers trait already used in parent class IOStream.
