### PR TITLE
Session unify resolve DefferedEvent

### DIFF
--- a/PHPDaemon/Examples/ExampleWebSocket.php
+++ b/PHPDaemon/Examples/ExampleWebSocket.php
@@ -40,7 +40,12 @@ class ExampleWebSocketRoute extends \PHPDaemon\WebSocket\Route {
 	 * @return void
 	 */
 	public function onHandshake() {
-		$this->client->onSessionStart(function ($event) {
+		$this->client->onSessionStart(function ($success) {
+			if (!$success) {
+				//session didn't start
+				return false;
+			}
+			//you can use $session or $this->client->session
 			if (!isset($this->client->session['counter'])) {
 				$this->client->session['counter'] = 0;
 			}

--- a/PHPDaemon/Exceptions/UndefinedEventCalled.php
+++ b/PHPDaemon/Exceptions/UndefinedEventCalled.php
@@ -1,0 +1,5 @@
+<?php
+namespace PHPDaemon\Exceptions;
+
+class UndefinedEventCalled extends \Exception {
+}

--- a/PHPDaemon/Traits/DeferredEventHandlers.php
+++ b/PHPDaemon/Traits/DeferredEventHandlers.php
@@ -30,7 +30,7 @@ trait DeferredEventHandlers {
 			return $this->{$event};
 		}
 		if (!method_exists($this, $event . 'Event')) {
-			throw new UndefinedEventCalledException('Undefined event called: ' . get_class($this). '->' . $event);
+			throw new \PHPDaemon\Exceptions\UndefinedEventCalled('Undefined event called: ' . get_class($this). '->' . $event);
 		}
 		$e = new DeferredEvent($this->{$event . 'Event'}());
 		$e->name = $event;


### PR DESCRIPTION
1) sometimes `setResult` have `true` sometimes empty.
if empty it didn't check
Now - only `true` or `false`, and it check if need
2) legacy UndefinedEventCalledException replaced
3) DeferredEventCmp cleanup
4) In examples  `$this->client->onSessionStart(function ($event)`, it can't be `$event` because we execute `CallbackStack` with arguments from `setResult`
