### PR TITLE
fixes: pcntl_sigtimedwait missing(on mac), composer syntax error

### DIFF
--- a/PHPDaemon/Thread/Generic.php
+++ b/PHPDaemon/Thread/Generic.php
@@ -440,7 +440,12 @@ abstract class Generic {
 	 */
 	protected function sigwait($sec = 0, $nano = 0.3e9) {
 		$siginfo = null;
-		$signo   = @\pcntl_sigtimedwait(array_keys(static::$signals), $siginfo, $sec, $nano);
+
+		if (!function_exists('pcntl_sigtimedwait')) {
+			$signo   = $this->sigtimedwait(array_keys(static::$signals), $siginfo, $sec, $nano);
+		} else {
+			$signo   = @\pcntl_sigtimedwait(array_keys(static::$signals), $siginfo, $sec, $nano);
+		}
 
 		if (is_bool($signo)) {
 			return $signo;
@@ -454,10 +459,17 @@ abstract class Generic {
 
 		return false;
 	}
-}
 
-if (!function_exists('pcntl_sigtimedwait')) { // For Mac OS where missing the orignal function
-	function pcntl_sigtimedwait($signals, $siginfo, $sec, $nano) {
+	/**
+	 * Implementation of pcntl_sigtimedwait for Mac.
+	 *
+	 * @param array Signal
+	 * @param null|array SigInfo
+	 * @param int Seconds
+	 * @param int Nanoseconds
+	 * @return boolean Success
+	 */
+	protected function sigtimedwait($signals, $siginfo, $sec, $nano) {
 		\pcntl_signal_dispatch();
 		if (\time_nanosleep($sec, $nano) === true) {
 			return false;

--- a/PHPDaemon/Utils/func.php
+++ b/PHPDaemon/Utils/func.php
@@ -28,6 +28,7 @@ if (!function_exists('igbinary_serialize')) {
 		return unserialize($m);
 	}
 }
+
 function setTimeout($cb, $timeout = null, $id = null, $priority = null) {
 	return \PHPDaemon\Core\Timer::add($cb, $timeout, $id, $priority);
 }

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "bin": ["bin/phpd"],
     "autoload": {
         "psr-0": { "PHPDaemon": "" },
-        "file": [
+        "files": [
             "PHPDaemon/Utils/func.php"
         ]
     }


### PR DESCRIPTION
The unexpected shutdown of master thread was caused by missing function on Mac OS. 
Related error infomation was suppress by "@", which took me lots of time in debugging : (

The previous solution in the project does not work on my laptop. signal-triggered function calls on protected method were outside the instance scope. so I move the code into an protected method in \PHPDaemon\Thread\Generic.
