### PR TITLE
Fixed autoloader issue when using with symfony framework autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name"  : "podarok/phpdaemon",
+    "name"  : "kakserpom/phpdaemon",
     "type"  : "library",
     "keywords": ["phpdaemon"],
-    "homepage": "https://github.com/podarok/phpdaemon",
+    "homepage": "https://github.com/kakserpom/phpdaemon",
     "license" : "GPL-3.0+",
     "description": "Asynchronous server-side framework for Web and network applications implemented in PHP using libevent. phpDaemon can handle thousands of simultaneous connections.",
     "authors" : [


### PR DESCRIPTION
If we want to use symfony framework inside event anonymous function we should check autoloader for already registered functions.
This patch fixes issue
