### PR TITLE
fix signal handler visibility

### DIFF
--- a/PHPDaemon/Thread/Generic.php
+++ b/PHPDaemon/Thread/Generic.php
@@ -240,7 +240,7 @@ abstract class Generic {
 	 * @param integer Signal's number
 	 * @return void
 	 */
-	protected function sighandler($signo) {
+	public function sighandler($signo) {
 		if (!isset(self::$signals[$signo])) {
 			$this->log('caught unknown signal #' . $signo);
 			return;


### PR DESCRIPTION
This leads to an following error if pcntl_signal_dispatchis called from the external application source

```
    2016-01-25 06:14:06 0.40551400 [26449]: Call to undefined method PHPDaemon\Thread\Worker->sighandler
    #0 [internal function]: PHPDaemon\Thread\Generic->__call('sighandler', Array)
    #1 [internal function]: PHPDaemon\Thread\Worker->sighandler(17)
    #2 /srv/ApplicationSource.php(330): pcntl_signal_dispatch()
```

Simple way to reproduce issue

```
    <?php
    abstract class AbstractClass {
    	public function init() {
    		if (!\pcntl_signal(SIGUSR1, [$this, 'sighandler'], true)) {
    			echo 'cannot setup signal', PHP_EOL;
    		}
    	}
    
    	protected function sighandler($signo) {
    		echo 'sighandler: ', $signo, PHP_EOL;
    	}
    }    

    class RealClass extends AbstractClass {
    
    	public function run() {
    		$this->init();
    	}
    }
    while(pcntl_signal_dispatch());
```

Will return PHP Warning:  Invalid callback RealClass::sighandler, cannot access protected method RealClass::sighandler()