### PR TITLE
Updated pecl-eio URI for CI

### DIFF
--- a/tests/ci/install.sh
+++ b/tests/ci/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Install ext-eio
-git clone https://bitbucket.org/osmanov/pecl-eio
+git clone https://github.com/rosmanov/pecl-eio.git
 pushd pecl-eio
 phpize
 ./configure


### PR DESCRIPTION
The pecl-eio repository has been moved from [Bitbucket](https://bitbucket.org/osmanov/pecl-eio) to [Github](https://github.com/rosmanov/pecl-eio).
