### PR TITLE
[FS\FileSystem] - remove parameters duplication in use (PHP 7.1 compa…

### DIFF
--- a/PHPDaemon/FS/FileSystem.php
+++ b/PHPDaemon/FS/FileSystem.php
@@ -525,7 +525,7 @@ class FileSystem
             $cb($path, file_get_contents($path));
             return true;
         }
-        return FileSystem::open($path, 'r!', function ($file) use ($path, $cb, $pri, $path) {
+        return FileSystem::open($path, 'r!', function ($file) use ($path, $cb, $pri) {
             if (!$file) {
                 $cb($path, false);
                 return;


### PR DESCRIPTION
…tibility)


Hey!

Caused error:

```
PHP Fatal error:  Cannot use variable $path twice in ......../vendor/kakserpom/phpdaemon/PHPDaemon/FS/FileSystem.php on line 535
```

Thanks