### PR TITLE
Fix HTTP client for urls like http://domain.com?param1=1

### DIFF
--- a/PHPDaemon/Clients/HTTP/Pool.php
+++ b/PHPDaemon/Clients/HTTP/Pool.php
@@ -60,6 +60,9 @@ class Pool extends Client
         }
         $u = parse_url($url);
         $uri = '';
+        if (!isset($u['path']) && isset($u['query'])) {
+            $u['path'] = '/';
+        }
         if (isset($u['path'])) {
             $uri .= $u['path'];
             if (isset($u['query'])) {


### PR DESCRIPTION
At this moment when you try to call url like 'http://domain.com?blabla=bla', without '/' after domain, via HTTP client,  it ignores query and calls just http://domain.com