### PR TITLE
#280 Websocket server drop connection on attempting to receive text (…

### DIFF
--- a/PHPDaemon/Servers/WebSocket/Protocols/V13.php
+++ b/PHPDaemon/Servers/WebSocket/Protocols/V13.php
@@ -224,7 +224,7 @@ class V13 extends Connection
                 }
                 if ($this->pool->maxAllowedPacket <= $dataLength) {
                     // Too big packet
-                    Daemon::log(get_class($this) . ': MaxAllowedPacket limit exeed. Packet size ' . $dataLength . ' bytes when limit ' . $this->pool->maxAllowedPacket . ' bytes');
+                    Daemon::log(get_class($this) . ': MaxAllowedPacket limit exceeded. Packet size ' . $dataLength . ' bytes when limit ' . $this->pool->maxAllowedPacket . ' bytes');
                     $this->finish();
                     return;
                 }

--- a/PHPDaemon/Servers/WebSocket/Protocols/V13.php
+++ b/PHPDaemon/Servers/WebSocket/Protocols/V13.php
@@ -201,7 +201,7 @@ class V13 extends Connection
                     $this->finish();
                     return;
                 }
-                if($this->firstFrameOpcodeName === null) {
+                if ($this->firstFrameOpcodeName === null) {
                     $this->firstFrameOpcodeName = $opcodeName;
                 }
                 $second = ord($this->look(1, 1)); // second byte integer (masked, payload length)


### PR DESCRIPTION
…JSON) message more than 65535 bytes

In attempt to accept the message splitted into fragments the server does not respond to the requests. The reason - incorrect watermark range on the "EventBufferEvent" input buffer. 

Also we have found out that the current WS protocol implementation doesn't correspond to RFC, namely section 4.4 Fragmentation (https://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-10#section-4.4)

According to RFC:

> A fragmented message consists of a single frame with the FIN bit
>       clear and an opcode other than 0, followed by zero or more frames
>       with the FIN bit clear and the opcode set to 0, and terminated by
>       a single frame with the FIN bit set and an opcode of 0.

The current implementation does not save first frame opcode value into variable.

This PR solves both problems described above.
